### PR TITLE
feat: add withdrawn domain status

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,16 @@ _Response JSON interface definitions below._
 
 _See `Policy` response below._
 
-| property     | description                      | type                                                      |
-|--------------|----------------------------------|-----------------------------------------------------------|
-| domain       | domain name                      | `string`                                                  |
-| description  | domain description               | `string`                                                  |
-| status       | consent status of `checkPolicy`  | `string` ("not-asked", "accepted", "declined", "expired") |
-| last-updated | date of last update              | `string` (ISO 8601 date)                                  |
-| expires      | date of expiry                   | `string` (ISO 8601 date)                                  |
-| ask-consent  | patient can be asked for consent | `boolean`                                                 |
-| policies     | domain name                      | Array of `Policy`                                         |
+| property     | description                      | type                                                     |
+|--------------|----------------------------------|----------------------------------------------------------|
+| domain       | domain name                      | `string`                                                 |
+| description  | domain description               | `string`                                                 |
+| status       | consent status of `checkPolicy`  | `string` ("accepted", "declined", "expired","withdrawn") |
+| last-updated | date of last update              | `string` (ISO 8601 date)                                 |
+| ask-consent  | patient can be asked for consent | `boolean`                                                |
+| policies     | domain name                      | Array of `Policy`                                        |
 
-⚠️ **NOTE**: `ask-consent` _can_ evaluate to `true`, if an existing valid consent exists but expires in less than a year.
+⚠️ **NOTE**: `ask-consent` _can_ evaluate to `true`, if an existing valid consent exists but will expire in less than a year.
 
 `Policy`
 
@@ -129,7 +128,6 @@ _See `Policy` response below._
 >      "description": "Broad Consent",
 >      "status": "declined",
 >      "last-updated": "2023-09-21T14:13:25.999+02:00",
->      "expires": "2028-09-21T00:00:00+02:00",
 >      "ask-consent": false,
 >      "policies": [
 >        {

--- a/pkg/consent/client_test.go
+++ b/pkg/consent/client_test.go
@@ -102,6 +102,44 @@ func TestGetTemplate(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestGetTemplate_WithErrors(t *testing.T) {
+
+	cases := []struct {
+		name string
+		data string
+		code int
+	}{
+		{
+			name: "errorResponse",
+			code: 400,
+		},
+		{
+			name: "invalidFhir",
+			data: "<invalid-fhir>",
+			code: 200,
+		},
+		{
+			name: "invalidFhir",
+			data: "{\"resourceType\": \"Bundle\", \"entry\": [{\"bla\":\"blubb\"}]}",
+			code: 200,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+
+			s := withTestServer([]byte(c.data), c.code)
+			defer s.Close()
+			c := NewGicsClient(config.AppConfig{Gics: config.Gics{
+				Fhir: config.Fhir{Base: s.URL + "/"},
+			}})
+
+			actual := c.GetTemplate("Test", "WITHDRAWAL")
+			assert.Equal(t, "", actual)
+		})
+	}
+}
+
 func withTestServer(response []byte, code int) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 

--- a/pkg/consent/client_test.go
+++ b/pkg/consent/client_test.go
@@ -57,6 +57,51 @@ func TestGetConsentPolicies(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestGetSourceReferenceTemplate(t *testing.T) {
+	templateUri := "Widerruf+%28kompatibel+zu+Patienteneinwilligung+MII+1.6d%29|2.0.a"
+
+	resp, _ := fhir.QuestionnaireResponse{
+		Questionnaire: of("https://ths-greifswald.de/fhir/gics/QuestionnaireComposed/MII/" + templateUri),
+	}.MarshalJSON()
+
+	s := withTestServer(resp, 200)
+	defer s.Close()
+
+	c := NewGicsClient(config.AppConfig{Gics: config.Gics{
+		Fhir: config.Fhir{Base: s.URL + "/"},
+	}})
+
+	template := c.GetSourceReferenceTemplate("QuestionnaireResponse/42")
+
+	assert.Equal(t, template, templateUri)
+}
+
+func TestGetTemplate(t *testing.T) {
+	expected := "Widerruf+%28kompatibel+zu+Patienteneinwilligung+MII+1.6d%29|2.0.a"
+	qs, _ := fhir.Questionnaire{
+		Code: []fhir.Coding{{
+			System: of("http://fhir.de/ConsentManagement/CodeSystem/TemplateType"),
+			Code:   of("WITHDRAWAL"),
+		}},
+		Url: of("https://ths-greifswald.de/fhir/gics/ConsentTemplate/MII/Widerruf+%28kompatibel+zu+Patienteneinwilligung+MII+1.6d%29|2.0.a"),
+	}.MarshalJSON()
+	b := &fhir.Bundle{Entry: []fhir.BundleEntry{
+		{Resource: qs},
+	}}
+	resp, _ := b.MarshalJSON()
+
+	s := withTestServer(resp, 200)
+	defer s.Close()
+
+	c := NewGicsClient(config.AppConfig{Gics: config.Gics{
+		Fhir: config.Fhir{Base: s.URL + "/"},
+	}})
+
+	actual := c.GetTemplate("Test", "WITHDRAWAL")
+
+	assert.Equal(t, expected, actual)
+}
+
 func withTestServer(response []byte, code int) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 

--- a/pkg/consent/domain.go
+++ b/pkg/consent/domain.go
@@ -11,6 +11,7 @@ import (
 const (
 	ContextIdentifierElementSystem = "http://fhir.de/ConsentManagement/StructureDefinition/ContextIdentifier"
 	ExternalPropertyElementSystem  = "https://ths-greifswald.de/fhir/StructureDefinition/gics/ExternalPropertyElement"
+	TemplateType                   = "http://fhir.de/ConsentManagement/CodeSystem/TemplateType"
 )
 
 type Domain struct {
@@ -19,6 +20,7 @@ type Domain struct {
 	CheckPolicyCode string
 	PersonIdSystem  string
 	Departments     []string
+	WithdrawalUri   string
 }
 
 func (d Domain) String() string {
@@ -41,7 +43,8 @@ func (d *DomainCache) Initialize() chan bool {
 
 	// initial call
 	d.IsHealthy = d.updateCache()
-	log.Info().Int("domains", len(d.Domains)).Str("update-interval", d.UpdateInterval.String()).Msg("Successfully initialized domains. Updating periodically.")
+	log.Info().Int("domains", len(d.Domains)).Str("update-interval", d.UpdateInterval.String()).
+		Msg("Successfully initialized domains. Updating periodically.")
 
 	// init polling
 	ticker := time.NewTicker(d.UpdateInterval)
@@ -100,6 +103,10 @@ func (d *DomainCache) updateCache() bool {
 			domain.CheckPolicyCode = val
 		} else {
 			continue
+		}
+
+		if t, e := d.Client.GetTemplate(domain.Name, "WITHDRAWAL"); e == nil {
+			domain.WithdrawalUri = t
 		}
 
 		result = append(result, domain)

--- a/pkg/consent/domain.go
+++ b/pkg/consent/domain.go
@@ -105,9 +105,8 @@ func (d *DomainCache) updateCache() bool {
 			continue
 		}
 
-		if t, e := d.Client.GetTemplate(domain.Name, "WITHDRAWAL"); e == nil {
-			domain.WithdrawalUri = t
-		}
+		// check withdrawal template uri
+		domain.WithdrawalUri = d.Client.GetTemplate(domain.Name, "WITHDRAWAL")
 
 		result = append(result, domain)
 	}

--- a/pkg/consent/domain_test.go
+++ b/pkg/consent/domain_test.go
@@ -116,6 +116,6 @@ func (c *TestGicsClient) GetTemplate(_ string, _ string) string {
 	return ""
 }
 
-func (c *TestGicsClient) GetSourceReferenceTemplate(_ string) string {
-	return ""
+func (c *TestGicsClient) GetSourceReferenceTemplate(ref string) string {
+	return ref
 }

--- a/pkg/consent/domain_test.go
+++ b/pkg/consent/domain_test.go
@@ -112,8 +112,8 @@ func (c *TestGicsClient) GetConsentPolicies(_ string, _ Domain) (*fhir.Bundle, e
 	return &fhir.Bundle{}, nil
 }
 
-func (c *TestGicsClient) GetTemplate(_ string, _ string) (string, error) {
-	return "", nil
+func (c *TestGicsClient) GetTemplate(_ string, _ string) string {
+	return ""
 }
 
 func (c *TestGicsClient) GetSourceReferenceTemplate(_ string) string {

--- a/pkg/consent/domain_test.go
+++ b/pkg/consent/domain_test.go
@@ -111,3 +111,11 @@ func (c *TestGicsClient) GetConsentPolicies(_ string, _ Domain) (*fhir.Bundle, e
 
 	return &fhir.Bundle{}, nil
 }
+
+func (c *TestGicsClient) GetTemplate(_ string, _ string) (string, error) {
+	return "", nil
+}
+
+func (c *TestGicsClient) GetSourceReferenceTemplate(_ string) string {
+	return ""
+}

--- a/pkg/consent/mapper.go
+++ b/pkg/consent/mapper.go
@@ -76,7 +76,7 @@ func ParseConsent(b *fhir.Bundle, domain Domain, c GicsClient) (*DomainStatus, e
 				// declined or withdrawn
 				ds.Status = Status(Declined).String()
 
-				if expires == noExpiryDate {
+				if noExpiryDate.Equal(expires) {
 					// check withdrawn state
 					if len(domain.WithdrawalUri) > 0 && domain.WithdrawalUri == c.GetSourceReferenceTemplate(*r.SourceReference.Reference) {
 						ds.Status = Status(Withdrawn).String()

--- a/pkg/consent/mapper.go
+++ b/pkg/consent/mapper.go
@@ -13,7 +13,6 @@ type DomainStatus struct {
 	Description string     `json:"description"`
 	Status      string     `json:"status"`
 	LastUpdated *time.Time `json:"last-updated"`
-	Expires     *time.Time `json:"expires"`
 	AskConsent  bool       `json:"ask-consent"`
 	Policies    []Policy   `json:"policies"`
 }
@@ -24,7 +23,7 @@ type Policy struct {
 	Code   string `json:"-"`
 }
 
-func ParseConsent(b *fhir.Bundle, domain Domain) (*DomainStatus, error) {
+func ParseConsent(b *fhir.Bundle, domain Domain, c GicsClient) (*DomainStatus, error) {
 
 	// fixed max date
 	noExpiryDate := time.Date(3000, 1, 1, 0, 0, 0, 0, time.Local)
@@ -45,7 +44,7 @@ func ParseConsent(b *fhir.Bundle, domain Domain) (*DomainStatus, error) {
 		r, _ := fhir.UnmarshalConsent(e.Resource)
 
 		// last updated
-		updated := parseTime(r.Meta.LastUpdated)
+		updated := parseTime(r.DateTime)
 		if ds.LastUpdated == nil || updated.After(*ds.LastUpdated) {
 			ds.LastUpdated = &updated
 		}
@@ -63,11 +62,6 @@ func ParseConsent(b *fhir.Bundle, domain Domain) (*DomainStatus, error) {
 		if p.Code == domain.CheckPolicyCode {
 			checkPolicyFound = true
 			expires := parseTime(r.Provision.Provision[0].Period.End)
-			if expires == noExpiryDate {
-				ds.Expires = nil
-			} else {
-				ds.Expires = &expires
-			}
 
 			ds.AskConsent = expires.Before(now.AddDate(1, 0, 0))
 
@@ -79,7 +73,17 @@ func ParseConsent(b *fhir.Bundle, domain Domain) (*DomainStatus, error) {
 				}
 
 			} else {
+				// declined or withdrawn
 				ds.Status = Status(Declined).String()
+
+				if expires == noExpiryDate {
+					// check withdrawn state
+					if len(domain.WithdrawalUri) > 0 && domain.WithdrawalUri == c.GetSourceReferenceTemplate(*r.SourceReference.Reference) {
+						ds.Status = Status(Withdrawn).String()
+					} else {
+						ds.Status = Status(Declined).String()
+					}
+				}
 			}
 		}
 	}
@@ -117,7 +121,7 @@ func parsePolicy(prov *fhir.ConsentProvision) (*Policy, error) {
 func parseTime(dt *string) time.Time {
 	t, err := time.Parse(time.RFC3339, *dt)
 	if err != nil {
-		log.Error().Err(err).Msg("Unable to parse lastUpdated from Consent resource")
+		log.Error().Err(err).Msg("Unable to parse time from RFC3339 string")
 		return time.Time{}
 	}
 	return t

--- a/pkg/consent/mapper.go
+++ b/pkg/consent/mapper.go
@@ -73,16 +73,12 @@ func ParseConsent(b *fhir.Bundle, domain Domain, c GicsClient) (*DomainStatus, e
 				}
 
 			} else {
-				// declined or withdrawn
+				// declined
 				ds.Status = Status(Declined).String()
 
-				if noExpiryDate.Equal(expires) {
-					// check withdrawn state
-					if len(domain.WithdrawalUri) > 0 && domain.WithdrawalUri == c.GetSourceReferenceTemplate(*r.SourceReference.Reference) {
-						ds.Status = Status(Withdrawn).String()
-					} else {
-						ds.Status = Status(Declined).String()
-					}
+				// check withdrawn state
+				if noExpiryDate.Equal(expires) && len(domain.WithdrawalUri) > 0 && domain.WithdrawalUri == c.GetSourceReferenceTemplate(*r.SourceReference.Reference) {
+					ds.Status = Status(Withdrawn).String()
 				}
 			}
 		}

--- a/pkg/consent/mapper_test.go
+++ b/pkg/consent/mapper_test.go
@@ -117,6 +117,46 @@ func TestParseConsent(t *testing.T) {
 				}, nil,
 			},
 		},
+		// expired check policy
+		{
+			name: "expiredCheckPolicy",
+			domain: Domain{
+				Name:            "Test",
+				Description:     "Test domain",
+				CheckPolicyCode: "MDAT_erheben",
+			},
+			policies: []fhir.Consent{
+				{
+					DateTime: of(now.Format(time.RFC3339)),
+					Provision: of(fhir.ConsentProvision{
+						Provision: []fhir.ConsentProvision{{
+							Type: of(fhir.ConsentProvisionTypePermit),
+							Period: &fhir.Period{
+								Start: of(now.AddDate(-10, 0, 0).Format(time.RFC3339)),
+								End:   of(now.AddDate(-5, 0, 0).Format(time.RFC3339)),
+							},
+							Code: []fhir.CodeableConcept{{
+								Coding: []fhir.Coding{{
+									System: of("https://ths-greifswald.de/fhir/CodeSystem/gics/Policy/MII"),
+									Code:   of("MDAT_erheben"),
+								}},
+							}},
+						}},
+					}),
+				}},
+			expected: Expected{
+				&DomainStatus{
+					Domain:      "Test",
+					Description: "Test domain",
+					Status:      "expired",
+					LastUpdated: &now,
+					AskConsent:  true,
+					Policies: []Policy{
+						{"MDAT_erheben", true, "MDAT_erheben"},
+					},
+				}, nil,
+			},
+		},
 		{
 			name: "failsWithInvalidCheckPolicy",
 			domain: Domain{

--- a/pkg/consent/mapper_test.go
+++ b/pkg/consent/mapper_test.go
@@ -44,7 +44,6 @@ func TestParseConsent(t *testing.T) {
 					Description: "Test domain",
 					Status:      "accepted",
 					LastUpdated: &now,
-					Expires:     of(now.AddDate(5, 0, 0)),
 					AskConsent:  false,
 					Policies: []Policy{
 						{"MDAT_erheben", true, "MDAT_erheben"},
@@ -103,9 +102,7 @@ func invalidate(c []fhir.Consent) []fhir.Consent {
 func getTestConsentPolicies(from time.Time) []fhir.Consent {
 	return []fhir.Consent{
 		{
-			Meta: &fhir.Meta{
-				LastUpdated: of(from.Format(time.RFC3339)),
-			},
+			DateTime: of(from.Format(time.RFC3339)),
 			Provision: of(fhir.ConsentProvision{
 				Provision: []fhir.ConsentProvision{{
 					Type: of(fhir.ConsentProvisionTypePermit),
@@ -123,9 +120,7 @@ func getTestConsentPolicies(from time.Time) []fhir.Consent {
 			}),
 		},
 		{
-			Meta: &fhir.Meta{
-				LastUpdated: of(from.Format(time.RFC3339)),
-			},
+			DateTime: of(from.Format(time.RFC3339)),
 			Provision: of(fhir.ConsentProvision{
 				Provision: []fhir.ConsentProvision{{
 					Type: of(fhir.ConsentProvisionTypeDeny),
@@ -156,7 +151,7 @@ func parseConsentHandler(t *testing.T, c ParseConsentTestCase) {
 	bundle := &fhir.Bundle{Entry: entries}
 
 	// act
-	res, err := ParseConsent(bundle, c.domain)
+	res, err := ParseConsent(bundle, c.domain, nil)
 
 	assert.Equal(t, c.expected.result, res)
 	assert.Equal(t, c.expected.error, err)

--- a/pkg/consent/mapper_test.go
+++ b/pkg/consent/mapper_test.go
@@ -29,7 +29,7 @@ func TestParseConsent(t *testing.T) {
 	// test cases
 	cases := []ParseConsentTestCase{
 		{
-			name: "parseConsent_Success",
+			name: "success",
 			domain: Domain{
 				Name:            "Test",
 				Description:     "Test domain",
@@ -52,8 +52,73 @@ func TestParseConsent(t *testing.T) {
 				}, nil,
 			},
 		},
+		// denied check policy
 		{
-			name: "parseConsent_FailsWithInvalidCheckPolicy",
+			name: "deniedCheckPolicy",
+			domain: Domain{
+				Name:            "Test",
+				Description:     "Test domain",
+				CheckPolicyCode: "MDAT_speichern_verarbeiten",
+			},
+			policies: getTestConsentPolicies(now),
+			expected: Expected{
+				&DomainStatus{
+					Domain:      "Test",
+					Description: "Test domain",
+					Status:      "declined",
+					LastUpdated: &now,
+					AskConsent:  false,
+					Policies: []Policy{
+						{"MDAT_erheben", true, "MDAT_erheben"},
+						{"MDAT_speichern_verarbeiten", false, "MDAT_speichern_verarbeiten"},
+					},
+				}, nil,
+			},
+		},
+		// withdrawn check policy
+		{
+			name: "withdrawnCheckPolicy",
+			domain: Domain{
+				Name:            "Test",
+				Description:     "Test domain",
+				CheckPolicyCode: "MDAT_erheben",
+				WithdrawalUri:   "WithdrawalTemplateUri",
+			},
+			policies: []fhir.Consent{
+				{
+					DateTime: of(now.Format(time.RFC3339)),
+					Provision: of(fhir.ConsentProvision{
+						Provision: []fhir.ConsentProvision{{
+							Type: of(fhir.ConsentProvisionTypeDeny),
+							Period: &fhir.Period{
+								Start: of(now.Format(time.RFC3339)),
+								End:   of(time.Date(3000, 1, 1, 0, 0, 0, 0, time.Local).Format(time.RFC3339)),
+							},
+							Code: []fhir.CodeableConcept{{
+								Coding: []fhir.Coding{{
+									System: of("https://ths-greifswald.de/fhir/CodeSystem/gics/Policy/MII"),
+									Code:   of("MDAT_erheben"),
+								}},
+							}},
+						}},
+					}),
+					SourceReference: &fhir.Reference{Reference: of("WithdrawalTemplateUri")},
+				}},
+			expected: Expected{
+				&DomainStatus{
+					Domain:      "Test",
+					Description: "Test domain",
+					Status:      "withdrawn",
+					LastUpdated: &now,
+					AskConsent:  false,
+					Policies: []Policy{
+						{"MDAT_erheben", false, "MDAT_erheben"},
+					},
+				}, nil,
+			},
+		},
+		{
+			name: "failsWithInvalidCheckPolicy",
 			domain: Domain{
 				Name:            "Test",
 				Description:     "Test domain",
@@ -68,7 +133,7 @@ func TestParseConsent(t *testing.T) {
 			},
 		},
 		{
-			name: "parseConsent_FailsWithNoPoliciesFound",
+			name: "failsWithNoPoliciesFound",
 			domain: Domain{
 				Name:            "Test",
 				Description:     "Test domain",
@@ -151,7 +216,7 @@ func parseConsentHandler(t *testing.T, c ParseConsentTestCase) {
 	bundle := &fhir.Bundle{Entry: entries}
 
 	// act
-	res, err := ParseConsent(bundle, c.domain, nil)
+	res, err := ParseConsent(bundle, c.domain, &TestGicsClient{})
 
 	assert.Equal(t, c.expected.result, res)
 	assert.Equal(t, c.expected.error, err)
@@ -220,6 +285,34 @@ func TestParsePolicy(t *testing.T) {
 			assert.Equal(t, c.expected, *actual)
 		})
 	}
+}
+
+func TestParseTime(t *testing.T) {
+	loc, _ := time.LoadLocation("Europe/Berlin")
+
+	cases := []struct {
+		name     string
+		date     string
+		expected time.Time
+	}{
+		{
+			"isValidDate",
+			"2023-12-21T12:42:00+01:00",
+			time.Date(2023, 12, 21, 12, 42, 0, 0, loc),
+		},
+		{
+			"isInvalidDate",
+			"invalid-date-string",
+			time.Time{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.WithinDuration(t, c.expected, parseTime(&c.date), 0)
+		})
+	}
+
 }
 
 func of[E any](e E) *E {

--- a/pkg/consent/status.go
+++ b/pkg/consent/status.go
@@ -7,8 +7,9 @@ const (
 	Accepted
 	Declined
 	Expired
+	Withdrawn
 )
 
 func (s Status) String() string {
-	return [...]string{"not-asked", "accepted", "declined", "expired"}[s]
+	return [...]string{"not-asked", "accepted", "declined", "expired", "withdrawn"}[s]
 }

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -124,7 +124,7 @@ func (s *Server) createDomainStatus(r StatusRequest, d consent.Domain) (*consent
 	}
 
 	// parse resources
-	ds, err := consent.ParseConsent(resp, d)
+	ds, err := consent.ParseConsent(resp, d, s.gicsClient)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to parse consent policies from gICS")
 		return nil, err

--- a/pkg/web/server_test.go
+++ b/pkg/web/server_test.go
@@ -60,7 +60,7 @@ func TestHandleConsentStatus(t *testing.T) {
 			requestUrl:     "/consent/status/42",
 			Auth:           testAuth,
 			responseStatus: 200,
-			response:       `[{"domain":"Test","description":"Test Consent","status":"accepted","last-updated":"<<PRESENCE>>","expires":"<<PRESENCE>>","ask-consent": false,"policies":[{"name": "IDAT_TEST","permit": true}]}]`,
+			response:       `[{"domain":"Test","description":"Test Consent","status":"accepted","last-updated":"<<PRESENCE>>","ask-consent": false,"policies":[{"name": "IDAT_TEST","permit": true}]}]`,
 		},
 	}
 
@@ -170,7 +170,7 @@ func (c *TestGicsClient) GetDomains() ([]fhir.ResearchStudy, error) {
 func (c *TestGicsClient) GetConsentPolicies(_ string, domain consent.Domain) (*fhir.Bundle, error) {
 	startTime := of(time.Now().Format(time.RFC3339))
 	r := fhir.Consent{
-		Meta: &fhir.Meta{LastUpdated: startTime},
+		DateTime: startTime,
 		Provision: &fhir.ConsentProvision{
 			Provision: []fhir.ConsentProvision{{
 				Type: of(fhir.ConsentProvisionTypePermit),
@@ -195,6 +195,14 @@ func (c *TestGicsClient) GetConsentPolicies(_ string, domain consent.Domain) (*f
 			Resource: cs,
 		}},
 	}, nil
+}
+
+func (c *TestGicsClient) GetTemplate(_ string, _ string) (string, error) {
+	return "", nil
+}
+
+func (c *TestGicsClient) GetSourceReferenceTemplate(_ string) string {
+	return ""
 }
 
 func TestCheckHealth(t *testing.T) {

--- a/pkg/web/server_test.go
+++ b/pkg/web/server_test.go
@@ -197,8 +197,8 @@ func (c *TestGicsClient) GetConsentPolicies(_ string, domain consent.Domain) (*f
 	}, nil
 }
 
-func (c *TestGicsClient) GetTemplate(_ string, _ string) (string, error) {
-	return "", nil
+func (c *TestGicsClient) GetTemplate(_ string, _ string) string {
+	return ""
 }
 
 func (c *TestGicsClient) GetSourceReferenceTemplate(_ string) string {


### PR DESCRIPTION
Currently, the following status responses are implemented: `not-asked`, `accepted`, `declined`, `expired`

In order to correctly reflect `withdrawn` and `declined` status response types should be changed.

- Add additional status response value `withdrawn` and change meaning of `declined` accordingly