### PR TITLE
Status is empty if no consent exists

### DIFF
--- a/pkg/consent/mapper.go
+++ b/pkg/consent/mapper.go
@@ -38,6 +38,11 @@ func ParseConsent(b *fhir.Bundle, domain Domain, c GicsClient) (*DomainStatus, e
 		Policies:    make([]Policy, 0),
 	}
 
+	// return if bundle is empty
+	if len(b.Entry) == 0 {
+		return &ds, nil
+	}
+
 	checkPolicyFound := false
 	// check consent resources
 	for _, e := range b.Entry {

--- a/pkg/consent/mapper_test.go
+++ b/pkg/consent/mapper_test.go
@@ -158,6 +158,27 @@ func TestParseConsent(t *testing.T) {
 			},
 		},
 		{
+			name: "consentNotAsked",
+			domain: Domain{
+				Name:            "Test",
+				Description:     "Test domain",
+				CheckPolicyCode: "MDAT_erheben",
+				PersonIdSystem:  "Patient-ID",
+			},
+			// not consent
+			policies: []fhir.Consent{},
+			expected: Expected{
+				&DomainStatus{
+					Domain:      "Test",
+					Description: "Test domain",
+					Status:      "not-asked",
+					LastUpdated: nil,
+					AskConsent:  true,
+					Policies:    []Policy{},
+				}, nil,
+			},
+		},
+		{
 			name: "failsWithInvalidCheckPolicy",
 			domain: Domain{
 				Name:            "Test",


### PR DESCRIPTION
There should always be a consent status result (for all eligible domains). 

If no consent is found, return a status response with `"status": "not-asked"`, no `last-updated` date and empty `policies`.

Example:
```json
[
  {
    "domain": "MII",
    "description": "Broad Consent",
    "status": "not-asked",
    "last-updated": null,
    "ask-consent": true,
    "policies": []
  }
]
```