### PR TITLE
Provide external consent document reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,20 @@ Detailed policy status information is available, too, and can be used to give fe
 
 ## Domain configuration (gICS)
 
-For a domain to be used in consent evaluation, it must be configured via external properties.
-The `checkPolicy` property is the only mandatory one that needs to be set. It should be set to the name of the 
-policy that is used to determine if a consent should be considered _accepted_.  
+For a domain to be used in consent evaluation, it must be configured via **external properties**.
+
+### checkPolicy
+
+The `checkPolicy` property is the only mandatory one that needs to be set. It should be set to the name of the
+policy that is used to determine if a consent should be considered _accepted_.
 
 Example for the MII Broad consent:
 
 ```sh
 checkPolicy=MDAT_erheben
 ```
+
+### departments
 
 Additionally, the `departments` property can be set to filter domains and only include them if explicitly requested. 
 The property value can be a single value or a list of comma seperated strings.
@@ -40,8 +45,20 @@ Data from those domains are part of the response if at least one of its values m
 }
 ```
 
-The body is optional in the request, though. In case it's missing only domains without the `departments` property set
+The body is optional in the request, though. In case it's missing, only domains without the `departments` property set
 are considered.
+
+### documentRef
+
+The `documentRef` property can be used to reference an _external_ document which is related to the consent of the domain 
+and should be returned as part of the consent status (i.e. `document-ref` response property).
+
+This property is optional.
+
+```sh
+documentRef=broad-consent-doc
+```
+
 
 ### Caching
 
@@ -88,14 +105,15 @@ _Response JSON interface definitions below._
 
 _See `Policy` response below._
 
-| property     | description                       | type                                                                 |
-|--------------|-----------------------------------|----------------------------------------------------------------------|
-| domain       | domain name                       | `string`                                                             |
-| description  | domain description                | `string`                                                             |
-| status       | consent status (of `checkPolicy`) | `string` ("accepted", "declined", "expired","withdrawn","not-asked") |
-| last-updated | date of last update               | `string` (ISO 8601 date)                                             |
-| ask-consent  | patient can be asked for consent  | `boolean`                                                            |
-| policies     | domain name                       | Array of `Policy`                                                    |
+| property      | description                       | type                                                                 |
+|---------------|-----------------------------------|----------------------------------------------------------------------|
+| domain        | domain name                       | `string`                                                             |
+| description   | domain description                | `string`                                                             |
+| document-ref  | external consent document id      | `string`                                                             |
+| status        | consent status (of `checkPolicy`) | `string` ("accepted", "declined", "expired","withdrawn","not-asked") |
+| last-updated  | date of last update               | `string` (ISO 8601 date)                                             |
+| ask-consent   | patient can be asked for consent  | `boolean`                                                            |
+| policies      | domain name                       | Array of `Policy`                                                    |
 
 ⚠️ **NOTE**: `ask-consent` _can_ evaluate to `true`, in case a valid consent exists that expires in less than a year.
 
@@ -126,6 +144,7 @@ _See `Policy` response below._
 >    {
 >      "domain": "MII",
 >      "description": "Broad Consent",
+>      "document-id": "bc-id",
 >      "status": "declined",
 >      "last-updated": "2023-09-21T14:13:25.999+02:00",
 >      "ask-consent": false,
@@ -147,9 +166,9 @@ _See `Policy` response below._
 >    {
 >      "domain": "Test",
 >      "description": "Test consent",
+>      "document-id": "test-id",
 >      "status": "not-asked",
 >      "last-updated": null,
->      "expires": null,
 >      "ask-consent": true,
 >      "policies": []
 >    }

--- a/pkg/consent/domain.go
+++ b/pkg/consent/domain.go
@@ -21,6 +21,7 @@ type Domain struct {
 	PersonIdSystem  string
 	Departments     []string
 	WithdrawalUri   string
+	DocumentRef     *string
 }
 
 func (d Domain) String() string {
@@ -96,12 +97,20 @@ func (d *DomainCache) updateCache() bool {
 
 		// external properties
 		props := parseExternalProperty(s.Extension)
+		// departments is optional
 		if val, ok := props["departments"]; ok {
 			domain.Departments = strings.Split(val, ",")
 		}
+		// documentRef is optional
+		if val, ok := props["documentRef"]; ok {
+			domain.DocumentRef = &val
+		}
+
+		// checkPolicy is required
 		if val, ok := props["checkPolicy"]; ok {
 			domain.CheckPolicyCode = val
 		} else {
+			log.Error().Str("domain", domain.Name).Str("property", "checkPolicy").Msg("Failed to parse external property from gICS domain")
 			continue
 		}
 

--- a/pkg/consent/domain_test.go
+++ b/pkg/consent/domain_test.go
@@ -24,12 +24,13 @@ func TestInitialize(t *testing.T) {
 		{
 			Name:            "Bar",
 			Description:     "Bar Domain",
+			DocumentRef:     of("bar-doc-id"),
 			CheckPolicyCode: "MDAT_erheben",
 			PersonIdSystem:  "https://ths-greifswald.de/fhir/gics/identifiers/Patienten-ID",
 			Departments:     []string{"bar-dep"},
 		}}
 
-	assert.Equal(t, expected, d.Domains)
+	assert.EqualValues(t, expected, d.Domains)
 }
 
 type TestGicsClient struct{}
@@ -65,12 +66,20 @@ func (c *TestGicsClient) GetDomains() ([]fhir.ResearchStudy, error) {
 					Extension: []fhir.Extension{
 						{Url: "key", ValueString: of("checkPolicy")},
 						{Url: "value", ValueString: of("MDAT_erheben")},
-					}},
+					},
+				},
 				{
 					Url: ExternalPropertyElementSystem,
 					Extension: []fhir.Extension{
 						{Url: "key", ValueString: of("departments")},
 						{Url: "value", ValueString: of("bar-dep")},
+					},
+				},
+				{
+					Url: ExternalPropertyElementSystem,
+					Extension: []fhir.Extension{
+						{Url: "key", ValueString: of("documentRef")},
+						{Url: "value", ValueString: of("bar-doc-id")},
 					},
 				},
 			},

--- a/pkg/consent/mapper.go
+++ b/pkg/consent/mapper.go
@@ -11,6 +11,7 @@ import (
 type DomainStatus struct {
 	Domain      string     `json:"domain"`
 	Description string     `json:"description"`
+	DocumentRef *string    `json:"document-ref"`
 	Status      string     `json:"status"`
 	LastUpdated *time.Time `json:"last-updated"`
 	AskConsent  bool       `json:"ask-consent"`
@@ -32,6 +33,7 @@ func ParseConsent(b *fhir.Bundle, domain Domain, c GicsClient) (*DomainStatus, e
 	ds := DomainStatus{
 		Domain:      domain.Name,
 		Description: domain.Description,
+		DocumentRef: domain.DocumentRef,
 		LastUpdated: nil,
 		AskConsent:  true,
 		Status:      Status(NotAsked).String(),

--- a/pkg/web/server_test.go
+++ b/pkg/web/server_test.go
@@ -60,7 +60,7 @@ func TestHandleConsentStatus(t *testing.T) {
 			requestUrl:     "/consent/status/42",
 			Auth:           testAuth,
 			responseStatus: 200,
-			response:       `[{"domain":"Test","description":"Test Consent","status":"accepted","last-updated":"<<PRESENCE>>","ask-consent": false,"policies":[{"name": "IDAT_TEST","permit": true}]}]`,
+			response:       `[{"domain":"Test","description":"Test Consent","document-ref":null,"status":"accepted","last-updated":"<<PRESENCE>>","ask-consent": false,"policies":[{"name": "IDAT_TEST","permit": true}]}]`,
 		},
 	}
 


### PR DESCRIPTION
Add response property to reference an external consent document relating to the gICS domain returned